### PR TITLE
Namespaces from driver, not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ return [
         'arangodb' => [
             'class' => '\devgroup\arangodb\Connection',
             'connectionOptions' => [
-                ArangoConnectionOptions::OPTION_DATABASE => "mydatabase",
-                ArangoConnectionOptions::OPTION_ENDPOINT => 'tcp://127.0.0.1:8529',
+                triagens\ArangoDb\ConnectionOptions::OPTION_DATABASE => "mydatabase",
+                triagens\ArangoDb\ConnectionOptions::OPTION_ENDPOINT => 'tcp://127.0.0.1:8529',
+                //triagens\ArangoDb\ConnectionOptions::OPTION_AUTH_USER   => '',
+                //triagens\ArangoDb\ConnectionOptions::OPTION_AUTH_PASSWD => '',
             ],
         ],
     ],


### PR DESCRIPTION
Better call absolute namespace

triagens\ArangoDb\ConnectionOptions

and add OPTION_AUTH_USER , OPTION_AUTH_PASSWD for authorization database
